### PR TITLE
Refactor: JWT 블랙리스트를 Redis로 전환

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,3 +22,5 @@ out/
 .env*
 *.log
 *.bak
+
+.claude/

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ out/
 ### macOS 시스템 파일 무시 ###
 .DS_Store
 **/.DS_Store
+
+.claude/

--- a/build.gradle
+++ b/build.gradle
@@ -149,6 +149,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'com.github.ben-manes.caffeine:caffeine'
 
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     // kafka
     implementation 'org.springframework.kafka:spring-kafka'
     testImplementation 'org.springframework.kafka:spring-kafka-test'

--- a/src/main/java/com/codeit/weatherwear/domain/security/JwtBlacklist.java
+++ b/src/main/java/com/codeit/weatherwear/domain/security/JwtBlacklist.java
@@ -1,34 +1,28 @@
 package com.codeit.weatherwear.domain.security;
 
+import java.time.Duration;
 import java.time.Instant;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Scheduled;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
-@Slf4j
+@RequiredArgsConstructor
 public class JwtBlacklist {
 
-  /**
-   * key = access token / value = expiration time
-   */
-  private Map<String, Instant> blacklist = new ConcurrentHashMap();
+  private static final String KEY_PREFIX = "jwt:blacklist:";
+
+  private final StringRedisTemplate redisTemplate;
 
   public void addBlacklist(String accessToken, Instant expirationTime) {
-    blacklist.put(accessToken, expirationTime);
+    Duration ttl = Duration.between(Instant.now(), expirationTime);
+    if (ttl.isNegative() || ttl.isZero()) {
+      return;
+    }
+    redisTemplate.opsForValue().set(KEY_PREFIX + accessToken, "", ttl);
   }
 
   public boolean existsInBlacklist(String accessToken) {
-    return blacklist.containsKey(accessToken);
-  }
-
-  // 메모리 누수 방지를 위해 1시간마다 만료된 액세스 토큰 삭제
-  @Scheduled(cron = "0 0 0/1 * * *")
-  public void cleanExpiredToken() {
-    log.info("Clean JwtBlacklist: delete expired access tokens in list");
-    Instant now = Instant.now();
-    blacklist.entrySet().removeIf(entry -> entry.getValue().isBefore(now));
+    return Boolean.TRUE.equals(redisTemplate.hasKey(KEY_PREFIX + accessToken));
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -61,6 +61,11 @@ spring:
   cache:
     type: caffeine
 
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
     producer:


### PR DESCRIPTION
## #️⃣ 연관 이슈
> ex) #이슈번호, #이슈번호

closes #2

### 🎯 PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가 (Feature)
- [x] 기능 수정 (Enhancement)
- [ ] 버그 수정 (Bugfix)
- [x] 리팩토링 (Refactor)
- [ ] 테스트 코드 추가 또는 수정 (Test)
- [ ] 문서 수정 (Docs)
- [ ] 주석 추가 / 제거 (Comment)
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트 (Chore)
- [ ] CI/CD 설정 (CI/CD)
- [ ] 스타일 수정 (예: prettier, lint 등) (Style)
- [ ] 기능 삭제 (Remove)

### 📝 반영 브랜치
> ex) feat/login -> dev

### 📑 변경 사항
> ex) 로그인 시, 구글 소셜 로그인 기능을 추가했습니다.

  기존 방식 (In-Memory ConcurrentHashMap)
                                              
  - Map<String, Instant> (token →
  만료시간)으로 블랙리스트를 메모리에 저장    
  - 메모리 누수 방지를 위해 @Scheduled로      
  1시간마다 만료 토큰을 수동 정리
  - 문제점: 서버가 여러 대일 경우 블랙리스트가
   공유되지 않고, 서버 재시작 시 블랙리스트가 
  사라짐

  변경된 방식 (Redis)

- build.gradle —   spring-boot-starter-data-redis 의존성 추가  
- application.yml — Redis 접속 정보 설정 (host, port 환경변수 지원)
- JwtBlacklist.java
  -  핵심 변경:
      - StringRedisTemplate을 사용하여 jwt:blacklist:{token} 키로 저장
      - TTL을 토큰 만료시간까지로 설정 → Redis가 자동으로 삭제해줌
      - 이미 만료된 토큰은 저장하지 않는 방어 로직 추가 (ttl.isNegative() || ttl.isZero())
      - @Scheduled 정리 작업이 완전히 제거됨 (Redis TTL이 대체)

주요 이점
- 다중 서버 환경에서 블랙리스트 공유 가능   
- 서버 재시작에도 블랙리스트 유지
- Redis TTL로 만료 처리가 자동화되어        
  스케줄러 코드 불필요


### 🛠 테스트 결과
> ex) 베이스 브랜치에 포함되기 위한 코드는 모두 정상적으로 동작해야 합니다. 결과물에 대한 스크린샷, GIF, 혹은 라이브 데모가 가능하도록 샘플API를 첨부할 수도 있습니다.

### ✅ PR 올리기 전 체크리스트

- [ ] 코드가 정상적으로 동작하며, 기존 기능을 해치지 않습니다.
- [ ] 코드 스타일 가이드에 맞춰 포맷팅되었습니다.
- [ ] 필요한 경우 관련 문서를 업데이트했습니다.